### PR TITLE
[#107033028] Add support for LDAP with STARTTLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -16,14 +16,20 @@ Role Variables
 The variables that can be passed to this role and a brief description about
 them are as follows:
 
-    openldap_serverdomain_name: example.com    # The domain prefix for ldap
-    openldap_serverrootpw: passme              # This is the password for admin for openldap
-    openldap_serverenable_ssl: true            # To enable/disable ssl for the ldap
-    openldap_servercountry: US                 # The self signed ssl certificate parameters
-    openldap_serverstate: Oregon
-    openldap_serverlocation: Portland
-    openldap_serverorganization: IT
-
+    openldap_server_hostname: ldap.example.com  # The hostname for ldap
+    openldap_server_domain_name: example.com    # The domain prefix for ldap
+    openldap_server_rootpw: passme              # This is the password for admin for openldap
+    openldap_server_enable_ssl: true            # To enable/disable ssl for the ldap
+    openldap_server_country: US                 # The self signed ssl certificate parameters
+    openldap_server_ssl_cacertificate:          # Downlaod CA certificate bundle
+    openldap_server_state: Oregon
+    openldap_server_location: Portland
+    openldap_server_organization: IT
+    openldap_server_tlscacertificatefile: /etc/openldap/certs/cacert.pem
+    openldap_server_certificate_expiry_days: 365
+    openldap_server_ssl_keylength: 2048         # SSL Keylength
+    openldap_server_ssl_private_key:            # Private Key
+    openldap_server_ssl_certificate:            # SSL Certificate
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Examples
         openldap_server_domain_name: example.com
         openldap_server_rootpw: passme
         openldap_server_enable_ssl: false
-       
+
 2) Configure an OpenLDAP server with SSL:
 
     - hosts: all

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 512
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "openldap"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.network :private_network, ip: "33.33.33.11"
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "site.yml"
+    ansible.verbose  = "v"
+  end
+end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ openldap_server_location: portland
 openldap_server_organization: IT
 openldap_server_certificate_expiry_days: 3650
 openldap_server_hostname: "{{ ansible_hostname }}"
+openldap_server_ssl_keylength: 1024
 
 openldap_server_enable_ssl: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ openldap_server_country: US
 openldap_server_state: oregon
 openldap_server_location: portland
 openldap_server_organization: IT
+openldap_server_certificate_expiry_days: 3650
+openldap_server_hostname: "{{ ansible_hostname }}"
 
 openldap_server_enable_ssl: true
 

--- a/files/ldap
+++ b/files/ldap
@@ -5,7 +5,7 @@
 #
 # Run slapd with -h "... ldap:/// ..."
 #   yes/no, default: yes
-SLAPD_LDAP=no
+SLAPD_LDAP=yes
 
 # Run slapd with -h "... ldapi:/// ..."
 #   yes/no, default: yes

--- a/files/slapd
+++ b/files/slapd
@@ -21,7 +21,7 @@ SLAPD_PIDFILE=
 # sockets.
 # Example usage:
 # SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
-SLAPD_SERVICES="ldaps:/// ldapi:///"
+SLAPD_SERVICES="ldap:/// ldapi:/// ldaps:///"
 
 # If SLAPD_NO_START is set, the init script will not start or restart
 # slapd (but stop will still work).  Uncomment this if you are

--- a/files/slapd_fedora
+++ b/files/slapd_fedora
@@ -6,7 +6,7 @@
 #   (use SASL with EXTERNAL mechanism for authentication)
 # - default: ldapi:/// ldap:///
 # - example: ldapi:/// ldap://127.0.0.1/ ldap://10.0.0.1:1389/ ldaps:///
-SLAPD_URLS="ldapi:/// ldaps:///"
+SLAPD_URLS="ldap:/// ldapi:/// ldaps:///"
 
 # Any custom options
 #SLAPD_OPTIONS=""

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  sudo: yes
+  vars:
+      openldap_server_ssl_cacertificate: true
+      openldap_server_tlscacertificatefile: /etc/ldap/certs/cacert.pem
+  roles:
+    - .

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -40,6 +40,11 @@
         owner={{ openldap_server_user }}
   when: openldap_server_ssl_certificate is defined
 
+- name: Download certificate chain file
+  get_url: url=https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt
+           dest={{ openldap_server_app_path }}/certs/cacert.pem
+           mode=0444
+  when: openldap_server_ssl_cacertificate is defined
 
 - name: copy the supporting files
   copy: src=ldap dest=/etc/sysconfig/ldap mode=0755

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -32,6 +32,14 @@
          -out cert.crt \
          -extensions v3_ca chdir={{ openldap_server_app_path }}/certs/
          creates={{ openldap_server_app_path }}/certs/cert.crt
+  when: openldap_server_ssl_certificate is undefined
+
+- name: Create the ssl certificate
+  copy: content='{{ openldap_server_ssl_certificate }}'
+        dest={{ openldap_server_app_path }}/certs/cert.crt
+        owner={{ openldap_server_user }}
+  when: openldap_server_ssl_certificate is defined
+
 
 - name: copy the supporting files
   copy: src=ldap dest=/etc/sysconfig/ldap mode=0755

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -11,8 +11,8 @@
          creates={{ openldap_server_app_path }}/certs/my1.key
   when: openldap_server_ssl_private_key is undefined
 
-- name: Strip the passphrase from the key 
-  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir={{ openldap_server_app_path }}/certs/ 
+- name: Strip the passphrase from the key
+  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir={{ openldap_server_app_path }}/certs/
          creates={{ openldap_server_app_path }}/certs/my.key
   when: openldap_server_ssl_private_key is undefined
 
@@ -49,25 +49,25 @@
 - name: copy the supporting files
   copy: src=ldap dest=/etc/sysconfig/ldap mode=0755
   when: openldap_server_enable_ssl and ansible_os_family == 'RedHat'
-  notify: 
+  notify:
    - restart slapd
 
 
 - name: copy the supporting files
   copy: src=slapd_fedora dest=/etc/sysconfig/slapd mode=0755
   when: openldap_server_enable_ssl and ansible_distribution == "Fedora"
-  notify: 
+  notify:
    - restart slapd
 
 - name: copy the supporting files
   copy: src=slapd dest=/etc/default/slapd mode=0755
   when: openldap_server_enable_ssl and ansible_os_family == 'Debian'
-  notify: 
+  notify:
    - restart slapd
 
 - name: start the slapd service
-  service: name=slapd state=started enabled=yes 
-  
+  service: name=slapd state=started enabled=yes
+
 - name: Copy the template for creating base dn
   template: src={{ openldap_server_ldif }} dest=/tmp/
   register: result

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -7,7 +7,7 @@
   file: path={{ openldap_server_app_path }}/certs/ state=directory owner={{ openldap_server_user }} group={{ openldap_server_user }}
 
 - name: Generate the private key for certificate request
-  shell: openssl genrsa -des3 -passout pass:password -out my1.key 1024 chdir={{ openldap_server_app_path }}/certs/ 
+  shell: openssl genrsa -des3 -passout pass:password -out my1.key {{ openldap_server_ssl_keylength }} chdir={{ openldap_server_app_path }}/certs/
          creates={{ openldap_server_app_path }}/certs/my1.key
 
 - name: Strip the passphrase from the key 

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -15,7 +15,15 @@
          creates={{ openldap_server_app_path }}/certs/my.key
 
 - name: Create and sign the the new certificate 
-  shell: openssl req -new -x509 -subj '/C={{ openldap_server_country }}/ST={{ openldap_server_state }}/L={{ openldap_server_location }}/O={{ openldap_server_organization }}/CN={{ ansible_hostname }}/' -days 3650 -key my.key -out cert.crt -extensions v3_ca chdir={{ openldap_server_app_path }}/certs/   creates={{ openldap_server_app_path }}/certs/cert.crt
+  shell: openssl req \
+         -new \
+         -x509 \
+         -subj '/C={{ openldap_server_country }}/ST={{ openldap_server_state }}/L={{ openldap_server_location }}/O={{ openldap_server_organization }}/CN={{ openldap_server_hostname }}/' \
+         -days {{ openldap_server_certificate_expiry_days }} \
+         -key my.key \
+         -out cert.crt \
+         -extensions v3_ca chdir={{ openldap_server_app_path }}/certs/
+         creates={{ openldap_server_app_path }}/certs/cert.crt
 
 - name: copy the supporting files
   copy: src=ldap dest=/etc/sysconfig/ldap mode=0755

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -9,10 +9,18 @@
 - name: Generate the private key for certificate request
   shell: openssl genrsa -des3 -passout pass:password -out my1.key {{ openldap_server_ssl_keylength }} chdir={{ openldap_server_app_path }}/certs/
          creates={{ openldap_server_app_path }}/certs/my1.key
+  when: openldap_server_ssl_private_key is undefined
 
 - name: Strip the passphrase from the key 
   shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir={{ openldap_server_app_path }}/certs/ 
          creates={{ openldap_server_app_path }}/certs/my.key
+  when: openldap_server_ssl_private_key is undefined
+
+- name: Create the ssl private key
+  copy: content='{{ openldap_server_ssl_private_key }}'
+        dest={{ openldap_server_app_path }}/certs/my.key
+        owner={{ openldap_server_user }}
+  when: openldap_server_ssl_private_key is defined
 
 - name: Create and sign the the new certificate 
   shell: openssl req \

--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -19,19 +19,19 @@
   file: path={{ openldap_server_app_path }}/slapd.d state=absent
 
 - name: Generate the root password for ldap
-  shell: slappasswd -s {{ openldap_server_rootpw }} 
+  shell: slappasswd -s {{ openldap_server_rootpw }}
   register: root_password
 
 - name: Copy the slapd.conf configuration file for Redhat
   template: src=slapd.conf.j2 dest={{ openldap_server_app_path }}/slapd.conf
   when: ansible_os_family == "RedHat"
-  notify: 
+  notify:
    - restart slapd
 
 - name: Copy the slapd.conf configuration file
   template: src=slapd.conf_ubuntu.j2 dest={{ openldap_server_app_path }}/slapd.conf
   when: ansible_os_family == "Debian"
-  notify: 
+  notify:
    - restart slapd
 
 - name: Copy the ldap.conf configuration file

--- a/templates/slapd.conf.j2
+++ b/templates/slapd.conf.j2
@@ -31,6 +31,8 @@ index uidNumber,gidNumber,loginShell    eq,pres
 index uid,memberUid                     eq,pres,sub
 index nisMapName,nisMapEntry            eq,pres,sub
 TLSCipherSuite HIGH:MEDIUM:+SSLv2
-#TLSCACertificateFile /etc/openldap/certs/cacert.pem
+{% if openldap_server_tlscacertificatefile is defined %}
+TLSCACertificateFile {{ openldap_server_tlscacertificatefile }}
+{% endif %}
 TLSCertificateFile /etc/openldap/certs/cert.crt
 TLSCertificateKeyFile /etc/openldap/certs/my.key

--- a/templates/slapd.conf_ubuntu.j2
+++ b/templates/slapd.conf_ubuntu.j2
@@ -36,6 +36,8 @@ index ou,cn,mail,surname,givenname      eq,pres,sub
 index uidNumber,gidNumber,loginShell    eq,pres
 index uid,memberUid                     eq,pres,sub
 index nisMapName,nisMapEntry            eq,pres,sub
-#TLSCACertificateFile /etc/ldap/certs/cacert.pem
+{% if openldap_server_tlscacertificatefile is defined %}
+TLSCACertificateFile {{ openldap_server_tlscacertificatefile }}
+{% endif %}
 TLSCertificateFile /etc/ldap/certs/cert.crt
 TLSCertificateKeyFile /etc/ldap/certs/my.key


### PR DESCRIPTION
## What

The version of the bennojoy/openldap_server role that we use does not support the following:
- LDAP with STARTTLS
- Using your own Certificate Authority signed SSL certificates

This PR intends to fix that
## How this PR should be reviewed

This PR has been crafted with the aid of dainty white mice wearing pink slippers to be reviewed with the following narrative:
- I want to:
  - Support all types of LDAP connection rather than just LDAPI and LDAPS (which has been deprecated)
  - Remove long and difficult to read lines of code and also make certain options like the `hostname` & `expiry date` overrideable
  - Parameterise the default SSL key size since the default is quite low by today's standards
  - Optionally use my own SSL private key
  - Optionally use my own SSL certificate
  - Optionally download a valid CA certificate bundle
  - Optionally use a `TLSCACertificateFile` on my LDAP server, so I can supply a valid CA certificate chain file if I ever want to use a valid SSL certificate
  - Update the documentation with new variables and fix any mistakes in the previous ones
  - Add a vagrant environment so I can test my changes in a disposal environment rather than on the live server
  - Invoke [The Boy Scout Rule](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule) and remove all the white space littered around the campground
## How to test this PR

A vagrant box has been provided for local testing, simply just:

```
vagrant up
```

You modify the `site.yml` to test the variables and run:

```
vagrant provision
```
## Who should review and merge this PR
- [Angelina Ballerina](http://cdn8.nflximg.net/images/5814/3625814.jpg) should review this PR, however if a mouse classically trained in the performance dance style of the Italian Renaissance courts can not be found then any member of the core team will do with the exception of @actionjack and @jimconner who lovingly crafted this PR for your entertainment and enjoyment
